### PR TITLE
Increase CoreSDK dependency version in watchOS Demo project

### DIFF
--- a/coresdk-integrations/coresdk-watchos/keyboard.xcodeproj/project.pbxproj
+++ b/coresdk-integrations/coresdk-watchos/keyboard.xcodeproj/project.pbxproj
@@ -604,7 +604,7 @@
 			repositoryURL = "https://github.com/FleksySDK/FleksyCoreSDK-iOS.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				minimumVersion = 1.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
* [FSDK-767] 📌 Set minimum version of CoreSDK to 1.2.1 in watchOS Demo project

[FSDK-767]: https://thingthing.atlassian.net/browse/FSDK-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ