### PR TITLE
Update iOS KeyboardSDK to v4.9.0

### DIFF
--- a/examples/open-view/ios/KeyboardFrameWithTextField/KeyboardFrameWithTextField.xcodeproj/project.pbxproj
+++ b/examples/open-view/ios/KeyboardFrameWithTextField/KeyboardFrameWithTextField.xcodeproj/project.pbxproj
@@ -607,7 +607,7 @@
 			repositoryURL = "https://github.com/FleksySDK/FleksySDK-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.6.0;
+				minimumVersion = 4.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/open-view/ios/KeyboardFrameWithTextField/keyboard/KeyboardFrameViewCustom.swift
+++ b/examples/open-view/ios/KeyboardFrameWithTextField/keyboard/KeyboardFrameViewCustom.swift
@@ -56,7 +56,7 @@ class KeyboardFrameViewCustom : KeyboardApp, AppTextFieldDelegate {
     
     @MainActor @objc func handleFullCover() {
         label?.text = nil
-        listener?.show(mode: .fullCover)
+        listener?.show(mode: .fullCover())
     }
     
     /// This is gonna be called automatically by the system when you close the View.

--- a/examples/open-view/ios/KeyboardOpenView/KeyboardOpenView.xcodeproj/project.pbxproj
+++ b/examples/open-view/ios/KeyboardOpenView/KeyboardOpenView.xcodeproj/project.pbxproj
@@ -607,7 +607,7 @@
 			repositoryURL = "https://github.com/FleksySDK/FleksySDK-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.6.0;
+				minimumVersion = 4.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/open-view/ios/KeyboardOpenView/keyboard/KeyboardOpenViewCustom.swift
+++ b/examples/open-view/ios/KeyboardOpenView/keyboard/KeyboardOpenViewCustom.swift
@@ -31,7 +31,7 @@ class KeyboardOpenViewCustom : KeyboardApp{
     }
     
     var defaultViewMode: KeyboardAppViewMode {
-        .fullCover // Shows the view over the keyboard, i.e. covering it.
+        .fullCover() // Shows the view over the keyboard, i.e. covering it.
     }
     
     ///

--- a/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp.xcodeproj/project.pbxproj
+++ b/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			repositoryURL = "https://github.com/FleksySDK/fleksyapps-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.0.1;
 			};
 		};
 		75F25B5B299FB30C00D884AB /* XCRemoteSwiftPackageReference "FleksySDK-iOS" */ = {
@@ -692,7 +692,7 @@
 			repositoryURL = "https://github.com/FleksySDK/FleksySDK-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.7.0;
+				minimumVersion = 4.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FleksySDK/fleksyapps-iOS",
       "state" : {
-        "revision" : "a2f0b54ca330ae548dce85770b316e523ba8bc1f",
-        "version" : "1.0.0"
+        "revision" : "354757052687cdb170c6c62715b818f455038827",
+        "version" : "1.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FleksySDK/FleksyEngine-iOS",
       "state" : {
-        "revision" : "7963be3c7589f31b2793e217d994b51a9da8d8f4",
-        "version" : "3.10.3"
+        "revision" : "a57304e98c959ca68238acf202e93085b7be3ca5",
+        "version" : "3.12.4"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FleksySDK/FleksySDK-iOS",
       "state" : {
-        "revision" : "463d401e3017238cee8b5e099e2447e8354cba48",
-        "version" : "4.7.1"
+        "revision" : "3a9fe1844e7071e665e48e57d845d0753a6e62bf",
+        "version" : "4.9.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FleksySDK/iOS-FleksyAppsCore",
       "state" : {
-        "revision" : "5c25b4eaceebe3e326d1576c3fda14ad77708b75",
-        "version" : "0.9.1"
+        "revision" : "fef4136a5dcfd8260e0f35f5bb65888db3965ddd",
+        "version" : "1.0.0"
       }
     }
   ],


### PR DESCRIPTION
* 📌 Update iOS KeyboardSDK to v4.9.0 in sample projects